### PR TITLE
Handle anonymous class expressions/declarations

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -47,11 +47,11 @@ module.exports = function myPlugin({ types: t }) {
   const classVisitor = {
     ClassDeclaration(path) {
       const pathBody = path.get('body');
-      visitorClassBody(pathBody, path.node.id.name);
+      visitorClassBody(pathBody, path.node.id != null ? path.node.id.name : 'AnonymousClass');
     },
     ClassExpression(path) {
       const pathBody = path.get('body');
-      visitorClassBody(pathBody, path.node.id.name);
+      visitorClassBody(pathBody, path.node.id != null ? path.node.id.name : 'AnonymousClass');
     },
   };
 


### PR DESCRIPTION
Classes can exists in code [anonymously](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/class#Examples), and in such cases `path.node.id` [will be null](http://astexplorer.net/#/gist/888dcf5cd1cbd696da652b1bce8d458d/cea789a8016f487446ce03c2c0902f66ac6832f8).

Here's an example:
```jsx
import React, { Component } from 'react';
import ErrorBoundary from '../components/ErrorBoundary';

export default (WrappedComponent) => class extends Component {
    render() {
        return (
            <ErrorBoundary errorType="Page Error">
                <WrappedComponent {...this.props} />
            </ErrorBoundary>
        );
    }
}
```
---

The other way to do this is to skip anonymous classes, but I am guessing that could be an option if anyone needs it. I personally find more useful a stmt like `AnonymousClass` providing a good hint, rather than no `displayName` at all, which then gets mangled when minifying the source.
  